### PR TITLE
Add real-time dashboard with WebSocket

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,6 +13,9 @@ const eventoRoutes = require('./src/routes/eventos.routes');
 const usuarioRoutes = require('./src/routes/usuarios.routes');
 const asistenciaRoutes = require('./src/routes/asistencia.routes');
 const locationRoutes = require('./src/routes/locationRoutes');
+const dashboardRoutes = require('./src/routes/dashboard.routes');
+
+const { initWebSocket } = require('./src/config/websocket');
 
 
 const swaggerUi = require('swagger-ui-express');
@@ -53,6 +56,7 @@ app.use('/api/usuarios', usuarioRoutes);
 app.use('/api/eventos', eventoRoutes);
 app.use('/api/asistencia', asistenciaRoutes);
 app.use('/api/location', locationRoutes);
+app.use('/api/dashboard', dashboardRoutes);
 
 
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(SwaggerDocumentation));
@@ -78,6 +82,7 @@ app.use((err, req, res, next) => {
 
 // Crear servidor y escuchar
 const server = http.createServer(app);
+initWebSocket(server);
 server.listen(port, () => {
   console.log(`🚀 Servidor escuchando en http://localhost:${port}`);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "morgan": "~1.9.1",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1",
-        "winston": "^3.17.0"
+        "winston": "^3.17.0",
+        "ws": "^8.18.3"
       },
       "devDependencies": {
         "nodemon": "^3.1.10",
@@ -2476,6 +2477,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yaml": {
       "version": "2.0.0-1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "morgan": "~1.9.1",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
-    "winston": "^3.17.0"
+    "winston": "^3.17.0",
+    "ws": "^8.18.3"
   },
   "devDependencies": {
     "nodemon": "^3.1.10",

--- a/src/config/websocket.js
+++ b/src/config/websocket.js
@@ -1,0 +1,19 @@
+let wss;
+
+function initWebSocket(server) {
+  const WebSocket = require('ws');
+  wss = new WebSocket.Server({ server });
+  console.log('🧩 WebSocket server iniciado');
+}
+
+function broadcast(data) {
+  if (!wss) return;
+  const msg = JSON.stringify(data);
+  wss.clients.forEach(client => {
+    if (client.readyState === client.OPEN) {
+      client.send(msg);
+    }
+  });
+}
+
+module.exports = { initWebSocket, broadcast };

--- a/src/controllers/dashboard.controller.js
+++ b/src/controllers/dashboard.controller.js
@@ -1,0 +1,29 @@
+const Dashboard = require('../models/dashboard.model');
+const { broadcast } = require('../config/websocket');
+
+exports.getMetrics = async (req, res) => {
+  try {
+    const metrics = await Dashboard.find().lean();
+    res.json(metrics);
+  } catch (err) {
+    res.status(500).json({ error: 'Error al obtener metricas', message: err.message });
+  }
+};
+
+exports.updateMetric = async (req, res) => {
+  const { metric, value } = req.body;
+  if (!metric || value === undefined) {
+    return res.status(400).json({ error: 'metric y value son requeridos' });
+  }
+  try {
+    const data = await Dashboard.findOneAndUpdate(
+      { metric },
+      { value },
+      { upsert: true, new: true, setDefaultsOnInsert: true }
+    );
+    broadcast({ type: 'metric-update', data });
+    res.json(data);
+  } catch (err) {
+    res.status(500).json({ error: 'Error al actualizar metrica', message: err.message });
+  }
+};

--- a/src/models/dashboard.model.js
+++ b/src/models/dashboard.model.js
@@ -1,0 +1,8 @@
+const mongoose = require('mongoose');
+
+const dashboardSchema = new mongoose.Schema({
+  metric: { type: String, required: true, unique: true },
+  value: { type: Number, default: 0 }
+}, { timestamps: true });
+
+module.exports = mongoose.model('Dashboard', dashboardSchema);

--- a/src/routes/dashboard.routes.js
+++ b/src/routes/dashboard.routes.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+const controller = require('../controllers/dashboard.controller');
+const auth = require('../middlewares/auth');
+
+// Obtener todas las metricas
+router.get('/metrics', auth(['admin','docente']), controller.getMetrics);
+// Actualizar o crear una metrica
+router.post('/metrics', auth(['admin','docente']), controller.updateMetric);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add dashboard model and controller
- expose dashboard routes
- set up WebSocket server and broadcast metric updates
- install ws dependency

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686318be5dd48330874522ebf53fabbe