### PR TITLE
Add real-time dashboard with WebSocket

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,6 +13,9 @@ const eventoRoutes = require('./src/routes/eventos.routes');
 const usuarioRoutes = require('./src/routes/usuarios.routes');
 const asistenciaRoutes = require('./src/routes/asistencia.routes');
 const locationRoutes = require('./src/routes/locationRoutes');
+const dashboardRoutes = require('./src/routes/dashboard.routes');
+
+const { initWebSocket } = require('./src/config/websocket');
 
 
 const swaggerUi = require('swagger-ui-express');
@@ -53,6 +56,7 @@ app.use('/api/usuarios', usuarioRoutes);
 app.use('/api/eventos', eventoRoutes);
 app.use('/api/asistencia', asistenciaRoutes);
 app.use('/api/location', locationRoutes);
+app.use('/api/dashboard', dashboardRoutes);
 
 
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(SwaggerDocumentation));
@@ -78,6 +82,7 @@ app.use((err, req, res, next) => {
 
 // Crear servidor y escuchar
 const server = http.createServer(app);
+initWebSocket(server);
 server.listen(port, () => {
   console.log(`🚀 Servidor escuchando en http://localhost:${port}`);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "morgan": "~1.9.1",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1",
-        "winston": "^3.17.0"
+        "winston": "^3.17.0",
+        "ws": "^8.18.3"
       },
       "devDependencies": {
         "nodemon": "^3.1.10",
@@ -2476,6 +2477,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yaml": {
       "version": "2.0.0-1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "morgan": "~1.9.1",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
-    "winston": "^3.17.0"
+    "winston": "^3.17.0",
+    "ws": "^8.18.3"
   },
   "devDependencies": {
     "nodemon": "^3.1.10",

--- a/src/config/websocket.js
+++ b/src/config/websocket.js
@@ -1,0 +1,19 @@
+let wss;
+
+function initWebSocket(server) {
+  const WebSocket = require('ws');
+  wss = new WebSocket.Server({ server });
+  console.log('🧩 WebSocket server iniciado');
+}
+
+function broadcast(data) {
+  if (!wss) return;
+  const msg = JSON.stringify(data);
+  wss.clients.forEach(client => {
+    if (client.readyState === client.OPEN) {
+      client.send(msg);
+    }
+  });
+}
+
+module.exports = { initWebSocket, broadcast };

--- a/src/controllers/asistencia.controllers.js
+++ b/src/controllers/asistencia.controllers.js
@@ -1,5 +1,6 @@
 const Evento = require('../models/model.evento');
 const Asistencia = require('../models/asistencia.model');
+const { incrementMetric } = require("../utils/dashboard.metrics");
 
 exports.registrarAsistencia = async (req, res) => {
   const { eventoId, latitud, longitud } = req.body;
@@ -26,6 +27,7 @@ exports.registrarAsistencia = async (req, res) => {
     });
 
     await asistencia.save();
+    await incrementMetric("asistencias");
     res.status(201).json({
       mensaje: dentroDelRango ? 'Asistencia registrada' : 'Fuera del rango',
       asistencia

--- a/src/controllers/dashboard.controller.js
+++ b/src/controllers/dashboard.controller.js
@@ -1,0 +1,29 @@
+const Dashboard = require('../models/dashboard.model');
+const { broadcast } = require('../config/websocket');
+
+exports.getMetrics = async (req, res) => {
+  try {
+    const metrics = await Dashboard.find().lean();
+    res.json(metrics);
+  } catch (err) {
+    res.status(500).json({ error: 'Error al obtener metricas', message: err.message });
+  }
+};
+
+exports.updateMetric = async (req, res) => {
+  const { metric, value } = req.body;
+  if (!metric || value === undefined) {
+    return res.status(400).json({ error: 'metric y value son requeridos' });
+  }
+  try {
+    const data = await Dashboard.findOneAndUpdate(
+      { metric },
+      { value },
+      { upsert: true, new: true, setDefaultsOnInsert: true }
+    );
+    broadcast({ type: 'metric-update', data });
+    res.json(data);
+  } catch (err) {
+    res.status(500).json({ error: 'Error al actualizar metrica', message: err.message });
+  }
+};

--- a/src/controllers/evento.controllers.js
+++ b/src/controllers/evento.controllers.js
@@ -1,5 +1,6 @@
 const Evento = require('../models/model.evento');
 const { stack } = require('../routes/locationRoutes');
+const { incrementMetric } = require("../utils/dashboard.metrics");
 
 // Crear un nuevo evento (solo docentes)
 // Crear un nuevo evento (solo docentes)
@@ -33,6 +34,7 @@ exports.crearEvento = async (req, res) => {
     });
 
     await nuevoEvento.save();
+    await incrementMetric("eventos");
 
     res.status(201).json({
       mensaje: 'Evento creado exitosamente',
@@ -128,6 +130,7 @@ exports.eliminarEvento = async (req, res) => {
     }
 
     await evento.deleteOne();
+    await incrementMetric("eventos", -1);
     res.status(200).json({ mensaje: 'Evento eliminado correctamente' });
   } catch (err) {
     res.status(500).json({ mensaje: 'Error al eliminar evento', error: err.message });

--- a/src/controllers/location.Controller.js
+++ b/src/controllers/location.Controller.js
@@ -1,5 +1,6 @@
 // controllers/locationController.js
 const UserLocation = require('../models/model.UserLocation');
+const { incrementMetric } = require("../utils/dashboard.metrics");
 
 // Coordenadas del punto central de geocerca
 const referenceLat = -0.1807;
@@ -40,6 +41,7 @@ exports.updateUserLocation = async (req, res) => {
         longitude,
         insideGeofence
       });
+      await incrementMetric("locations");
     }
 
     return res.json({ insideGeofence, distance });

--- a/src/controllers/usuarios.controller.js
+++ b/src/controllers/usuarios.controller.js
@@ -1,6 +1,7 @@
 const Usuario = require('../models/Model.user');
 const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
+const { incrementMetric } = require("../utils/dashboard.metrics");
 
 // Registro de usuario
 exports.registrarUsuario = async (req, res) => {
@@ -27,6 +28,7 @@ exports.registrarUsuario = async (req, res) => {
     });
 
     await nuevoUsuario.save();
+    await incrementMetric("usuarios");
 
     res.status(201).json({ mensaje: '✅ Usuario registrado correctamente' });
   } catch (err) {

--- a/src/models/dashboard.model.js
+++ b/src/models/dashboard.model.js
@@ -1,0 +1,8 @@
+const mongoose = require('mongoose');
+
+const dashboardSchema = new mongoose.Schema({
+  metric: { type: String, required: true, unique: true },
+  value: { type: Number, default: 0 }
+}, { timestamps: true });
+
+module.exports = mongoose.model('Dashboard', dashboardSchema);

--- a/src/routes/dashboard.routes.js
+++ b/src/routes/dashboard.routes.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+const controller = require('../controllers/dashboard.controller');
+const auth = require('../middlewares/auth');
+
+// Obtener todas las metricas
+router.get('/metrics', auth(['admin','docente']), controller.getMetrics);
+// Actualizar o crear una metrica
+router.post('/metrics', auth(['admin','docente']), controller.updateMetric);
+
+module.exports = router;

--- a/src/utils/dashboard.metrics.js
+++ b/src/utils/dashboard.metrics.js
@@ -1,0 +1,18 @@
+const Dashboard = require('../models/dashboard.model');
+const { broadcast } = require('../config/websocket');
+
+async function incrementMetric(metric, delta = 1) {
+  try {
+    const doc = await Dashboard.findOneAndUpdate(
+      { metric },
+      { $inc: { value: delta } },
+      { upsert: true, new: true, setDefaultsOnInsert: true }
+    );
+    broadcast({ type: 'metric-update', data: doc });
+    return doc;
+  } catch (err) {
+    console.error('Failed to increment metric', metric, err);
+  }
+}
+
+module.exports = { incrementMetric };


### PR DESCRIPTION
## Summary
- add dashboard model and controller
- expose dashboard routes
- set up WebSocket server and broadcast metric updates
- install ws dependency
- track metrics in controllers for dashboard statistics

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686318be5dd48330874522ebf53fabbe