### PR TITLE
Check duplicate attendance

### DIFF
--- a/src/controllers/asistencia.controllers.js
+++ b/src/controllers/asistencia.controllers.js
@@ -10,6 +10,17 @@ exports.registrarAsistencia = async (req, res) => {
     const evento = await Evento.findById(eventoId);
     if (!evento) return res.status(404).json({ mensaje: 'Evento no encontrado' });
 
+    // Validar que el estudiante no haya registrado asistencia previamente
+    const asistenciaExistente = await Asistencia.findOne({
+      estudiante: estudianteId,
+      evento: eventoId,
+    });
+    if (asistenciaExistente) {
+      return res.status(400).json({
+        mensaje: 'El estudiante ya registró asistencia para este evento',
+      });
+    }
+
     const distancia = calcularDistancia(
       evento.ubicacion.latitud,
       evento.ubicacion.longitud,
@@ -19,11 +30,22 @@ exports.registrarAsistencia = async (req, res) => {
 
     const dentroDelRango = distancia <= evento.rangoPermitido;
 
+    const ahora = Date.now();
+    const inicioEvento = new Date(evento.fechaInicio).getTime();
+
+    if (!dentroDelRango && ahora - inicioEvento <= 10 * 60 * 1000) {
+      return res.status(400).json({
+        mensaje: 'Fuera del rango. Tienes 10 minutos para regresar y marcar asistencia'
+      });
+    }
+
     const asistencia = new Asistencia({
       estudiante: estudianteId,
       evento: eventoId,
       coordenadas: { latitud, longitud },
-      dentroDelRango
+      dentroDelRango,
+      estado: dentroDelRango ? 'presente' : 'ausente',
+      fueraDesde: dentroDelRango ? undefined : new Date()
     });
 
     await asistencia.save();

--- a/src/controllers/evento.controllers.js
+++ b/src/controllers/evento.controllers.js
@@ -1,8 +1,6 @@
 const Evento = require('../models/model.evento');
-const { stack } = require('../routes/locationRoutes');
 const { incrementMetric } = require("../utils/dashboard.metrics");
 
-// Crear un nuevo evento (solo docentes)
 // Crear un nuevo evento (solo docentes)
 exports.crearEvento = async (req, res) => {
   try {
@@ -62,10 +60,8 @@ exports.obtenerEventos = async (req, res) => {
       error: err.message,
       stack: err.stack, // información detallada para debugging
     });
-    console.log('Tipo de Evento:', typeof Evento);
-  console.log('Contenido de Evento:', Evento);
 
-  }
+    }
 };
 
 // Obtener evento por ID

--- a/src/models/asistencia.model.js
+++ b/src/models/asistencia.model.js
@@ -29,8 +29,17 @@ const asistenciaSchema = new mongoose.Schema({
     type: Boolean,
     required: true,
   },
+  estado: {
+    type: String,
+    enum: ['presente', 'ausente'],
+    default: 'presente'
+  },
+  fueraDesde: Date
 }, {
   timestamps: true // Opcional: agrega createdAt y updatedAt automáticamente
 });
+
+// Evita múltiples asistencias del mismo estudiante en un evento
+asistenciaSchema.index({ estudiante: 1, evento: 1 }, { unique: true });
 
 module.exports = mongoose.model('Asistencia', asistenciaSchema);

--- a/src/models/model.evento.js
+++ b/src/models/model.evento.js
@@ -16,8 +16,7 @@ const eventoSchema = new mongoose.Schema({
     required: true,
   }
 }, {
-  timestamps: true // ✅ esto está bien
+  timestamps: true
 });
-
 
 module.exports = mongoose.model('Evento', eventoSchema);

--- a/src/routes/eventos.routes.js
+++ b/src/routes/eventos.routes.js
@@ -1,11 +1,18 @@
 const express = require('express');
 const router = express.Router();
-const {crearEvento, actualizarEvento, obtenerEventos, eliminarEvento} = require('../controllers/evento.controllers');
+const {
+  crearEvento,
+  actualizarEvento,
+  obtenerEventos,
+  obtenerEventoPorId,
+  eliminarEvento
+} = require('../controllers/evento.controllers');
 const authMiddleware = require('../middlewares/auth');
 
 router.post('/crear', authMiddleware(['docente', 'admin']), crearEvento);
 
 router.get('/', obtenerEventos);
+router.get('/:id', obtenerEventoPorId);
 
 router.put('/:id', authMiddleware(['docente', 'admin']), actualizarEvento);
 


### PR DESCRIPTION
## Summary
- prevent a student from registering more than once per event
- add unique index for `estudiante`+`evento` in the attendance model
- mark attendance as absent if user stays outside for more than 10 minutes
- reject attendance registration if outside range within the 10-minute grace period
- clean up event controller and add GET route for single events

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68634b567cd88330a03fa934ddf40ef2