### PR TITLE
Add soft delete for events

### DIFF
--- a/src/controllers/asistencia.controllers.js
+++ b/src/controllers/asistencia.controllers.js
@@ -8,7 +8,7 @@ exports.registrarAsistencia = async (req, res) => {
 
   try {
     // Buscar evento
-    const evento = await Evento.findById(eventoId);
+    const evento = await Evento.findOne({ _id: eventoId, activo: true });
     if (!evento) {
       return res.status(404).json({ mensaje: 'Evento no encontrado' });
     }

--- a/src/controllers/evento.controllers.js
+++ b/src/controllers/evento.controllers.js
@@ -51,7 +51,7 @@ exports.crearEvento = async (req, res) => {
 // Obtener todos los eventos
 exports.obtenerEventos = async (req, res) => {
   try {
-    const eventos = await Evento.find().populate('creadoPor', 'nombre email rol');
+    const eventos = await Evento.find({ activo: true }).populate('creadoPor', 'nombre email rol');
     res.status(200).json(eventos);
   } catch (err) {
     console.error('Error al obtener eventos:', err); // imprime el error completo en consola
@@ -67,7 +67,7 @@ exports.obtenerEventos = async (req, res) => {
 // Obtener evento por ID
 exports.obtenerEventoPorId = async (req, res) => {
   try {
-    const evento = await Evento.findById(req.params.id).populate('creadoPor', 'nombre email');
+    const evento = await Evento.findOne({ _id: req.params.id, activo: true }).populate('creadoPor', 'nombre email');
     if (!evento) return res.status(404).json({ mensaje: 'Evento no encontrado' });
     res.status(200).json(evento);
   } catch (err) {
@@ -79,7 +79,7 @@ exports.obtenerEventoPorId = async (req, res) => {
 exports.actualizarEvento = async (req, res) => {
   try {
     const evento = await Evento.findById(req.params.id);
-    if (!evento) {
+    if (!evento || !evento.activo) {
       return res.status(404).json({ mensaje: 'Evento no encontrado' });
     }
 
@@ -119,13 +119,14 @@ exports.actualizarEvento = async (req, res) => {
 exports.eliminarEvento = async (req, res) => {
   try {
     const evento = await Evento.findById(req.params.id);
-    if (!evento) return res.status(404).json({ mensaje: 'Evento no encontrado' });
+    if (!evento || !evento.activo) return res.status(404).json({ mensaje: 'Evento no encontrado' });
 
     if (evento.creadoPor.toString() !== req.user.id && req.user.rol !== 'admin', 'docente') {
       return res.status(403).json({ mensaje: 'No tienes permiso para eliminar este evento' });
     }
 
-    await evento.deleteOne();
+    evento.activo = false;
+    await evento.save();
     await incrementMetric("eventos", -1);
     res.status(200).json({ mensaje: 'Evento eliminado correctamente' });
   } catch (err) {

--- a/src/controllers/location.Controller.js
+++ b/src/controllers/location.Controller.js
@@ -37,7 +37,7 @@ exports.updateUserLocation = async (req, res) => {
     let rango = GEOFENCE_RADIUS;
 
     if (eventoId) {
-      const evento = await Evento.findById(eventoId);
+      const evento = await Evento.findOne({ _id: eventoId, activo: true });
       if (evento) {
         lat = evento.ubicacion.latitud;
         lon = evento.ubicacion.longitud;

--- a/src/models/model.evento.js
+++ b/src/models/model.evento.js
@@ -37,6 +37,10 @@ const eventoSchema = new mongoose.Schema({
     default: 100,
     min: [0, 'El rango permitido no puede ser negativo']
   },
+  activo: {
+    type: Boolean,
+    default: true
+  },
   creadoPor: {
     type: mongoose.Schema.Types.ObjectId,
     ref: 'Usuario',


### PR DESCRIPTION
## Summary
- add `activo` field to `Evento` model
- filter queries by active events
- mark events inactive instead of deleting

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686abda6497483308eb7f89e5bf375a9