### PR TITLE
Implement pending user verification flow

### DIFF
--- a/src/models/pendingUser.model.js
+++ b/src/models/pendingUser.model.js
@@ -1,0 +1,20 @@
+const mongoose = require('mongoose');
+
+const pendingUserSchema = new mongoose.Schema({
+  nombre: { type: String, required: true },
+  correo: { type: String, required: true, unique: true },
+  contrasena: { type: String, required: true },
+  rol: {
+    type: String,
+    enum: ['estudiante', 'docente', 'admin'],
+    default: 'estudiante',
+  },
+  codigoVerificacion: { type: String, required: true },
+  expiresAt: {
+    type: Date,
+    default: Date.now,
+    index: { expires: '1h' },
+  },
+});
+
+module.exports = mongoose.model('PendingUser', pendingUserSchema);


### PR DESCRIPTION
## Summary
- add `PendingUser` model with automatic TTL deletion
- register users in `PendingUser` until email is verified
- only create `Usuario` after successful verification
- block login if email not verified

## Testing
- `node -e "require('./src/models/pendingUser.model');"`
- `node -e "require('./src/controllers/usuarios.controller.js');"`
- `PORT=3000 node app.js` *(fails: querySrv ENOTFOUND cluster0.nadpe6y.mongodb.net)*

------
https://chatgpt.com/codex/tasks/task_e_68784a4deca483309154899eab134b10