### PR TITLE
Allow optional event dates

### DIFF
--- a/src/controllers/asistencia.controllers.js
+++ b/src/controllers/asistencia.controllers.js
@@ -36,7 +36,12 @@ exports.registrarAsistencia = async (req, res) => {
 
     // Lógica de estado según hora y rango
     const ahora = Date.now();
-    const inicioEvento = new Date(evento.fechaInicio).getTime();
+    let inicioEvento = evento.fechaInicio ? new Date(evento.fechaInicio) : new Date();
+    if (evento.horaInicio) {
+      const [h, m = 0] = evento.horaInicio.split(":" ).map(Number);
+      inicioEvento.setHours(h, m, 0, 0);
+    }
+    inicioEvento = inicioEvento.getTime();
 
     let estado = 'Ausente';
     if (dentroDelRango) {

--- a/src/models/model.evento.js
+++ b/src/models/model.evento.js
@@ -13,11 +13,23 @@ const eventoSchema = new mongoose.Schema({
   },
   fechaInicio: {
     type: Date,
-    required: [true, 'La fecha de inicio es obligatoria']
   },
   fechaFin: {
     type: Date,
-    required: [true, 'La fecha de fin es obligatoria']
+  },
+  duracionDias: {
+    type: Number,
+    default: 1
+  },
+  horaInicio: {
+    type: String,
+  },
+  horaFin: {
+    type: String,
+  },
+  duracionHoras: {
+    type: Number,
+    default: 1
   },
   lugar: {
     type: String,

--- a/src/routes/eventos.routes.js
+++ b/src/routes/eventos.routes.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const router = express.Router();
+// Las fechas y horas son opcionales; se puede indicar la duracion en dias u horas del evento
 const {
   crearEvento,
   actualizarEvento,


### PR DESCRIPTION
## Summary
- make `fechaInicio` and `fechaFin` optional and add `duracionDias`
- add `horaInicio`, `horaFin` and `duracionHoras` for event times
- adapt controllers to compute end date/time from provided durations
- handle event start time in asistencia controller
- document in routes that dates and times are optional

## Testing
- `npm run test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688a567986948330a7b3fef4574e6376