### PR TITLE
Implement per-event dashboard metrics

### DIFF
--- a/src/controllers/asistencia.controllers.js
+++ b/src/controllers/asistencia.controllers.js
@@ -1,6 +1,7 @@
 const Evento = require('../models/model.evento');
 const Asistencia = require('../models/asistencia.model');
 const { incrementMetric } = require("../utils/dashboard.metrics");
+const { incrementEventMetric } = require("../utils/event.metrics");
 
 exports.registrarAsistencia = async (req, res) => {
   const { eventoId, latitud, longitud } = req.body;
@@ -66,6 +67,7 @@ exports.registrarAsistencia = async (req, res) => {
 
     await asistencia.save();
     await incrementMetric("asistencias");
+    await incrementEventMetric(eventoId, dentroDelRango ? 'dentroDelRango' : 'fueraDelRango');
 
     // Responder
     res.status(201).json({

--- a/src/controllers/dashboard.controller.js
+++ b/src/controllers/dashboard.controller.js
@@ -1,5 +1,6 @@
 const Dashboard = require('../models/dashboard.model');
 const { broadcast } = require('../config/websocket');
+const EventMetric = require('../models/eventMetric.model');
 
 exports.getMetrics = async (req, res) => {
   try {
@@ -25,5 +26,14 @@ exports.updateMetric = async (req, res) => {
     res.json(data);
   } catch (err) {
     res.status(500).json({ error: 'Error al actualizar metrica', message: err.message });
+  }
+};
+
+exports.getEventMetrics = async (req, res) => {
+  try {
+    const metrics = await EventMetric.findOne({ evento: req.params.id }).lean();
+    res.json(metrics || {});
+  } catch (err) {
+    res.status(500).json({ error: 'Error al obtener metricas de evento', message: err.message });
   }
 };

--- a/src/controllers/evento.controllers.js
+++ b/src/controllers/evento.controllers.js
@@ -1,6 +1,6 @@
 const Evento = require('../models/model.evento');
 const { incrementMetric } = require("../utils/dashboard.metrics");
-const Dashboard = require('../models/dashboard.model');
+const EventMetric = require('../models/eventMetric.model');
 const { generateEventPDFBase64 } = require('../utils/pdf.util');
 
 // Crear un nuevo evento (solo docentes)
@@ -218,7 +218,7 @@ exports.finalizarEvento = async (req, res) => {
 
     evento.estado = 'finalizado';
 
-    const metrics = await Dashboard.find().lean();
+    const metrics = await EventMetric.findOne({ evento: evento._id }).lean();
     const pdfBase64 = await generateEventPDFBase64(evento.toObject(), metrics);
 
     evento.reportePDF = pdfBase64;

--- a/src/controllers/location.Controller.js
+++ b/src/controllers/location.Controller.js
@@ -3,6 +3,7 @@ const UserLocation = require('../models/model.UserLocation');
 const Evento = require('../models/model.evento');
 const Asistencia = require('../models/asistencia.model');
 const { incrementMetric } = require("../utils/dashboard.metrics");
+const { incrementEventMetric } = require("../utils/event.metrics");
 
 // Coordenadas del punto central de geocerca
 const referenceLat = -0.1807;
@@ -57,6 +58,15 @@ exports.updateUserLocation = async (req, res) => {
         insideGeofence
       });
       await incrementMetric("locations");
+      if (eventoId) {
+        // Ajustar conteo de estudiantes dentro y fuera del rango
+        if (previousState === undefined) {
+          await incrementEventMetric(eventoId, insideGeofence ? 'dentroDelRango' : 'fueraDelRango');
+        } else {
+          await incrementEventMetric(eventoId, insideGeofence ? 'dentroDelRango' : 'fueraDelRango');
+          await incrementEventMetric(eventoId, insideGeofence ? 'fueraDelRango' : 'dentroDelRango', -1);
+        }
+      }
     }
 
     if (eventoId) {

--- a/src/models/eventMetric.model.js
+++ b/src/models/eventMetric.model.js
@@ -1,0 +1,9 @@
+const mongoose = require('mongoose');
+
+const eventMetricSchema = new mongoose.Schema({
+  evento: { type: mongoose.Schema.Types.ObjectId, ref: 'Evento', required: true, unique: true },
+  dentroDelRango: { type: Number, default: 0 },
+  fueraDelRango: { type: Number, default: 0 }
+}, { timestamps: true });
+
+module.exports = mongoose.model('EventMetric', eventMetricSchema);

--- a/src/routes/dashboard.routes.js
+++ b/src/routes/dashboard.routes.js
@@ -7,5 +7,6 @@ const auth = require('../middlewares/auth');
 router.get('/metrics', auth(['admin','docente']), controller.getMetrics);
 // Actualizar o crear una metrica
 router.post('/metrics', auth(['admin','docente']), controller.updateMetric);
+router.get('/metrics/event/:id', auth(['admin','docente']), controller.getEventMetrics);
 
 module.exports = router;

--- a/src/utils/event.metrics.js
+++ b/src/utils/event.metrics.js
@@ -1,0 +1,19 @@
+const EventMetric = require('../models/eventMetric.model');
+const { broadcast } = require('../config/websocket');
+
+async function incrementEventMetric(evento, field, delta = 1) {
+  try {
+    const update = { $inc: { [field]: delta } };
+    const doc = await EventMetric.findOneAndUpdate(
+      { evento },
+      update,
+      { upsert: true, new: true, setDefaultsOnInsert: true }
+    );
+    broadcast({ type: 'event-metric-update', evento: String(evento), data: doc });
+    return doc;
+  } catch (err) {
+    console.error('Failed to increment event metric', field, err);
+  }
+}
+
+module.exports = { incrementEventMetric };

--- a/src/utils/pdf.util.js
+++ b/src/utils/pdf.util.js
@@ -24,11 +24,19 @@ async function generateEventPDFBase64(evento, metrics = []) {
       if (evento.descripcion) doc.text(`Descripcion: ${evento.descripcion}`);
       doc.moveDown();
 
-      if (metrics && metrics.length) {
+      if (metrics && Array.isArray(metrics) && metrics.length) {
         doc.text('Métricas Dashboard:', { underline: true });
         metrics.forEach(m => {
           doc.text(`${m.metric}: ${m.value}`);
         });
+      } else if (metrics && typeof metrics === 'object' && !Array.isArray(metrics)) {
+        doc.text('Métricas Evento:', { underline: true });
+        if (metrics.dentroDelRango !== undefined) {
+          doc.text(`Dentro del rango: ${metrics.dentroDelRango}`);
+        }
+        if (metrics.fueraDelRango !== undefined) {
+          doc.text(`Fuera del rango: ${metrics.fueraDelRango}`);
+        }
       }
 
       doc.end();


### PR DESCRIPTION
## Summary
- add model to store metrics per event
- count in-range and out-of-range students when updating locations and registering attendance
- expose API endpoint to fetch metrics of a specific event
- include event metrics in event finalization PDF

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688a852b64a883309519c6ea0ad0ee34