### PR TITLE
Add teacher events listing

### DIFF
--- a/src/controllers/evento.controller.js
+++ b/src/controllers/evento.controller.js
@@ -234,3 +234,17 @@ exports.finalizarEvento = async (req, res) => {
     res.status(500).json({ mensaje: 'Error al finalizar evento', error: err.message });
   }
 };
+
+// Obtener eventos creados por el docente/admin
+exports.obtenerMisEventos = async (req, res) => {
+  try {
+    const { estado } = req.query;
+    const filtro = { creadorId: req.user.id };
+    if (estado) filtro.estado = estado;
+
+    const eventos = await Evento.find(filtro).populate('creadorId', 'nombre email rol');
+    res.status(200).json(eventos);
+  } catch (err) {
+    res.status(500).json({ mensaje: 'Error al obtener mis eventos', error: err.message });
+  }
+};

--- a/src/routes/eventos.routes.js
+++ b/src/routes/eventos.routes.js
@@ -7,12 +7,14 @@ const {
   obtenerEventos,
   obtenerEventoPorId,
   eliminarEvento,
-  finalizarEvento
+  finalizarEvento,
+  obtenerMisEventos
 } = require('../controllers/evento.controller');
 const authMiddleware = require('../middlewares/auth');
 
 router.post('/crear', authMiddleware(['docente', 'admin']), crearEvento);
 
+router.get('/mis', authMiddleware(['docente', 'admin']), obtenerMisEventos);
 router.get('/', obtenerEventos);
 router.get('/:id', obtenerEventoPorId);
 

--- a/swagger_output.json
+++ b/swagger_output.json
@@ -932,6 +932,37 @@
           }
         }
       }
+    },
+    "/api/eventos/mis": {
+      "get": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "type": "string"
+          },
+          {
+            "name": "estado",
+            "in": "query",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- add controller to list events created by logged-in user
- expose new `/api/eventos/mis` endpoint
- document new endpoint in swagger output

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688ab0b875908330a1f7fc95eed87ac5