### PR TITLE
feat: allow docentes to request verification codes

### DIFF
--- a/src/controllers/usuarios.controller.js
+++ b/src/controllers/usuarios.controller.js
@@ -23,24 +23,28 @@ exports.registrarUsuario = async (req, res) => {
 
     const hashed = await bcrypt.hash(contrasena, 10);
 
-    const codigo = Math.floor(100000 + Math.random() * 900000).toString();
-    const hashedCode = await bcrypt.hash(codigo, 10);
+    const basePendiente = { nombre, correo, contrasena: hashed, rol };
 
-    const nuevoPendiente = new PendingUser({
-      nombre,
-      correo,
-      contrasena: hashed,
-      rol,
-      codigoVerificacion: hashedCode,
-    });
+    // Para estudiantes se envía el código inmediatamente
+    if (rol !== 'docente') {
+      const codigo = Math.floor(100000 + Math.random() * 900000).toString();
+      const hashedCode = await bcrypt.hash(codigo, 10);
+      basePendiente.codigoVerificacion = hashedCode;
 
+      const nuevoPendiente = new PendingUser(basePendiente);
+      await nuevoPendiente.save();
+      await enviarCorreo(
+        correo,
+        'Código de verificación',
+        `Tu código de verificación es: ${codigo}`
+      );
+      return res.status(201).json({ mensaje: '✅ Usuario registrado. Revisa tu correo para verificarlo.' });
+    }
+
+    // Para docentes se crea el registro pero el código se envía bajo demanda
+    const nuevoPendiente = new PendingUser(basePendiente);
     await nuevoPendiente.save();
-    await enviarCorreo(
-      correo,
-      'Código de verificación',
-      `Tu código de verificación es: ${codigo}`
-    );
-    res.status(201).json({ mensaje: '✅ Usuario registrado. Revisa tu correo para verificarlo.' });
+    return res.status(201).json({ mensaje: '✅ Docente registrado. Usa el botón para enviar el código de verificación.' });
   } catch (err) {
     console.error('[Registro] Error:', err);
     res.status(500).json({ error: 'Error al registrar el usuario' });
@@ -197,6 +201,34 @@ exports.obtenerPerfil = async (req, res) => {
   }
 };
 
+// Enviar código de verificación para docentes registrados
+exports.enviarCodigoDocente = async (req, res) => {
+  try {
+    const { correo } = req.body;
+    const pendiente = await PendingUser.findOne({ correo, rol: 'docente' });
+    if (!pendiente) {
+      return res.status(404).json({ ok: false, mensaje: 'Docente pendiente no encontrado' });
+    }
+
+    const codigo = Math.floor(100000 + Math.random() * 900000).toString();
+    const hashedCode = await bcrypt.hash(codigo, 10);
+    pendiente.codigoVerificacion = hashedCode;
+    pendiente.expiresAt = Date.now();
+    await pendiente.save();
+
+    await enviarCorreo(
+      correo,
+      'Código de verificación',
+      `Tu código de verificación es: ${codigo}`
+    );
+
+    return res.status(200).json({ ok: true, mensaje: 'Código enviado' });
+  } catch (error) {
+    console.error('[EnviarCodigoDocente] Error:', error);
+    return res.status(500).json({ ok: false, mensaje: 'Error al enviar el código' });
+  }
+};
+
 // Verificar correo electrónico
 exports.verificarCorreo = async (req, res) => {
   try {
@@ -204,6 +236,9 @@ exports.verificarCorreo = async (req, res) => {
     const pendiente = await PendingUser.findOne({ correo });
     if (!pendiente) {
       return res.status(404).json({ ok: false, mensaje: 'Registro pendiente no encontrado o expirado' });
+    }
+    if (!pendiente.codigoVerificacion) {
+      return res.status(400).json({ ok: false, mensaje: 'Código no solicitado' });
     }
     const esValido = await bcrypt.compare(codigo, pendiente.codigoVerificacion);
     if (!esValido) {

--- a/src/models/pendingUser.model.js
+++ b/src/models/pendingUser.model.js
@@ -9,7 +9,8 @@ const pendingUserSchema = new mongoose.Schema({
     enum: ['estudiante', 'docente', 'admin'],
     default: 'estudiante',
   },
-  codigoVerificacion: { type: String, required: true },
+  // El código de verificación se genera cuando se solicita
+  codigoVerificacion: { type: String },
   expiresAt: {
     type: Date,
     default: Date.now,

--- a/src/routes/usuarios.routes.js
+++ b/src/routes/usuarios.routes.js
@@ -1,9 +1,11 @@
 const express = require('express');
 const router = express.Router();
-const { registrarUsuario, iniciarSesion, actualizarUsuario, obtenerPerfil, verificarCorreo } = require('../controllers/usuarios.controller');
+const { registrarUsuario, iniciarSesion, actualizarUsuario, obtenerPerfil, verificarCorreo, enviarCodigoDocente } = require('../controllers/usuarios.controller');
 const auth =  require('../middlewares/auth');
 
 router.post('/registrar', registrarUsuario);
+
+router.post('/docente/enviar-codigo', enviarCodigoDocente);
 
 router.post('/verificar-correo', verificarCorreo);
 


### PR DESCRIPTION
## Summary
- allow registration to defer verification emails for `docente`
- add endpoint to send verification codes to pending docentes
- validate that code exists before verifying a user

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68919116a02083308053505b7337a16b