### PR TITLE
feat: list teacher events in overview

### DIFF
--- a/src/controllers/dashboard.controller.js
+++ b/src/controllers/dashboard.controller.js
@@ -120,7 +120,10 @@ exports.getDashboardOverview = async (req, res) => {
     ]);
     const asistenciaPorHora = horaAgg.map(h => ({ hora: h._id, total: h.total }));
 
-    const actividadReciente = await Evento.find({ ...eventFilter, estado: 'activo' }, 'nombre fechaInicio fechaFin createdAt').sort({ createdAt: -1 }).lean();
+    const eventosDocente = await Evento
+      .find(eventFilter, 'nombre fechaInicio fechaFin estado createdAt')
+      .sort({ createdAt: -1 })
+      .lean();
 
     res.json({
       totalEventos,
@@ -133,7 +136,7 @@ exports.getDashboardOverview = async (req, res) => {
       tendenciaAsistenciaMensual,
       asistenciaPorDia,
       asistenciaPorHora,
-      actividadReciente
+      eventosDocente
     });
   } catch (err) {
     res.status(500).json({ error: 'Error al obtener estadisticas', message: err.message });


### PR DESCRIPTION
## Summary
- show only events created by the logged teacher on dashboard overview

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6893bd70c19c83309cd9a6926733a4a2