### PR TITLE
Filtra métricas del dashboard por docente

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Cada una de estas dependencias se puede consultar en `package.json`.
   - Registro de asistencia validando la ubicación del estudiante.
   - Módulo de justificaciones y generación de reportes en PDF.
   - Endpoint `/dashboard/overview` para visualizar métricas generales del sistema.
+    - Cuando un docente consulta este endpoint solo ve estadísticas de los eventos que ha creado.
 - Se encuentran en progreso ajustes en el dashboard de métricas y mejoras en las notificaciones en tiempo real.
 
 ## Estado del desarrollo y próximos pasos


### PR DESCRIPTION
## Summary
- Limit dashboard overview metrics to events created by the authenticated docente
- Document filtering logic in controller and README for better clarity

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6893bab14360833095148a3825517f0e