### PR TITLE
feat: iniciar y finalizar eventos automaticamente

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Este esquema muestra el flujo de una petición: el usuario realiza una solicitud
 - **JWT (jsonwebtoken)**: autenticación de usuarios.
 - **bcryptjs**: cifrado de contraseñas.
 - **Nodemailer**: envío de correos de verificación.
-- **node-cron**: tareas programadas para actualizar asistencias.
+- **node-cron**: tareas programadas para actualizar asistencias y eventos.
 - **ws**: canal WebSocket para enviar actualizaciones en tiempo real.
 - **pdfkit**: generación de reportes en PDF.
 - **swagger-jsdoc / swagger-ui-express**: documentación interactiva de la API.
@@ -77,8 +77,22 @@ Cada una de estas dependencias se puede consultar en `package.json`.
   - Creación y gestión de eventos (docentes/administradores).
   - Registro de asistencia validando la ubicación del estudiante.
   - Módulo de justificaciones y generación de reportes en PDF.
-  - Endpoint `/dashboard/overview` para visualizar métricas generales del sistema.
+- Endpoint `/dashboard/overview` para visualizar métricas generales del sistema.
 - Se encuentran en progreso ajustes en el dashboard de métricas y mejoras en las notificaciones en tiempo real.
+
+## Cron de eventos
+
+Una tarea programada (`src/cron/eventoCron.js`) se ejecuta cada minuto usando `node-cron`. Revisa los eventos con estado `activo` cuya `fechaInicio` y `horaInicio` ya ocurrieron y cambia su estado a `En proceso`. También monitorea los eventos `En proceso` y los marca como `finalizado` cuando su `fechaFin` y `horaFin` han concluido. Al iniciar la aplicación, esta tarea se carga automáticamente desde `app.js`.
+
+Si un evento abarca varios días, tras finalizar la hora configurada de la jornada actual cambia a `En espera` para indicar formalmente que continuará al día siguiente hasta llegar a su `fechaFin`.
+
+Los eventos pueden tener los siguientes estados:
+
+- `activo`: creado y pendiente de iniciar.
+- `En proceso`: la fecha y hora de inicio ya pasaron.
+- `En espera`: la jornada actual terminó y continuará al día siguiente.
+- `finalizado`: concluyó con normalidad.
+- `cancelado`: fue suspendido antes de iniciar o concluir.
 
 ## Estado del desarrollo y próximos pasos
 

--- a/app.js
+++ b/app.js
@@ -18,6 +18,7 @@ const justificacionRoutes = require('./src/routes/justificaciones.routes');
 const testRoutes = require('./src/routes/test.routes');
 
 require('./src/cron/asistenciaCron');
+require('./src/cron/eventoCron');
 
 const { initWebSocket } = require('./src/config/websocket');
 

--- a/src/cron/eventoCron.js
+++ b/src/cron/eventoCron.js
@@ -1,0 +1,107 @@
+const cron = require('node-cron');
+const Evento = require('../models/model.evento');
+
+/**
+ * Determina si un evento ya debería estar en proceso
+ * @param {Object} evento - Documento de evento
+ * @param {Date} now - Fecha actual
+ * @returns {boolean}
+ */
+function debeIniciarEvento(evento, now = new Date()) {
+  if (!evento.fechaInicio || !evento.horaInicio) return false;
+  const [hours, minutes] = evento.horaInicio.split(':').map(Number);
+  const inicio = new Date(evento.fechaInicio);
+  inicio.setHours(hours, minutes, 0, 0);
+  return inicio <= now;
+}
+
+/**
+ * Determina si un evento ya debería finalizar
+ * @param {Object} evento - Documento de evento
+ * @param {Date} now - Fecha actual
+ * @returns {boolean}
+ */
+function debeFinalizarEvento(evento, now = new Date()) {
+  if (!evento.fechaFin || !evento.horaFin) return false;
+  const [hours, minutes] = evento.horaFin.split(':').map(Number);
+  const fin = new Date(evento.fechaFin);
+  fin.setHours(hours, minutes, 0, 0);
+  return fin <= now;
+}
+
+/**
+ * Indica si el evento continúa al día siguiente
+ * @param {Object} evento - Documento de evento
+ * @param {Date} now - Fecha actual
+ * @returns {boolean}
+ */
+function continuaManana(evento, now = new Date()) {
+  if (!evento.fechaFin || !evento.horaFin) return false;
+  const fechaFin = new Date(evento.fechaFin);
+  if (now.toDateString() === fechaFin.toDateString()) return false;
+  const [hours, minutes] = evento.horaFin.split(':').map(Number);
+  const finHoy = new Date(now);
+  finHoy.setHours(hours, minutes, 0, 0);
+  return now > finHoy && now < fechaFin;
+}
+
+/**
+ * Determina si un evento en espera debe reanudarse
+ * @param {Object} evento - Documento de evento
+ * @param {Date} now - Fecha actual
+ * @returns {boolean}
+ */
+function debeReanudarEvento(evento, now = new Date()) {
+  if (!evento.horaInicio || !evento.fechaFin) return false;
+  const [hours, minutes] = evento.horaInicio.split(':').map(Number);
+  const inicioHoy = new Date(now);
+  inicioHoy.setHours(hours, minutes, 0, 0);
+  if (now > new Date(evento.fechaFin)) return false;
+  return now >= inicioHoy;
+}
+
+/**
+ * Consulta eventos y actualiza su estado según la fecha y hora.
+ * @param {Date} now - Fecha actual (para pruebas)
+ */
+async function actualizarEventosEnProceso(now = new Date()) {
+  try {
+    const [activos, enProceso, enEspera] = await Promise.all([
+      Evento.find({ estado: 'activo', fechaInicio: { $lte: now } }),
+      Evento.find({ estado: 'En proceso' }),
+      Evento.find({ estado: 'En espera' })
+    ]);
+
+    for (const evento of activos) {
+      if (debeIniciarEvento(evento, now)) {
+        evento.estado = 'En proceso';
+        await evento.save();
+      }
+    }
+
+    for (const evento of enProceso) {
+      if (debeFinalizarEvento(evento, now)) {
+        evento.estado = 'finalizado';
+        await evento.save();
+      } else if (continuaManana(evento, now)) {
+        evento.estado = 'En espera';
+        await evento.save();
+        console.info(`Evento "${evento.nombre}" continuará el día siguiente`);
+      }
+    }
+
+    for (const evento of enEspera) {
+      if (debeReanudarEvento(evento, now)) {
+        evento.estado = 'En proceso';
+        await evento.save();
+      }
+    }
+  } catch (error) {
+    console.error('Error en cron de eventos:', error);
+  }
+}
+
+cron.schedule('* * * * *', () => actualizarEventosEnProceso());
+
+module.exports = { actualizarEventosEnProceso, debeIniciarEvento, debeFinalizarEvento, continuaManana, debeReanudarEvento };
+

--- a/src/models/model.evento.js
+++ b/src/models/model.evento.js
@@ -57,7 +57,7 @@ const eventoSchema = new mongoose.Schema({
   },
   estado: {
     type: String,
-    enum: ['activo', 'finalizado', 'cancelado', 'En proceso'],
+    enum: ['activo', 'finalizado', 'cancelado', 'En proceso', 'En espera'],
     default: 'activo'
   },
   reportePDF: { type: String },

--- a/src/test/eventoCron.test.js
+++ b/src/test/eventoCron.test.js
@@ -1,0 +1,69 @@
+const assert = require('assert');
+const Evento = require('../models/model.evento');
+const { actualizarEventosEnProceso } = require('../cron/eventoCron');
+
+(async () => {
+  const now = new Date('2024-01-01T18:00:00Z');
+
+  const eventosActivos = [
+    {
+      nombre: 'Evento Activo',
+      fechaInicio: new Date('2024-01-01'),
+      horaInicio: '17:00',
+      estado: 'activo',
+      async save() { this.saved = true; }
+    }
+  ];
+
+  const eventoFinaliza = {
+    nombre: 'Evento Finaliza',
+    fechaFin: new Date('2024-01-01'),
+    horaFin: '17:00',
+    estado: 'En proceso',
+    async save() { this.saved = true; }
+  };
+
+  const eventoMultidia = {
+    nombre: 'Evento Multidia',
+    fechaFin: new Date('2024-01-03'),
+    horaFin: '17:00',
+    horaInicio: '17:00',
+    estado: 'En proceso',
+    async save() { this.saved = true; }
+  };
+
+  const eventosEnProceso = [eventoFinaliza, eventoMultidia];
+
+  Evento.find = async (query) => {
+    if (query.estado === 'activo') return eventosActivos;
+    if (query.estado === 'En proceso') return eventosEnProceso;
+    if (query.estado === 'En espera') return [];
+    return [];
+  };
+
+  const logs = [];
+  console.info = (msg) => logs.push(msg);
+
+  await actualizarEventosEnProceso(now);
+
+  assert.strictEqual(eventosActivos[0].estado, 'En proceso', 'Evento activo debe iniciar');
+  assert.strictEqual(eventoFinaliza.estado, 'finalizado', 'Evento terminado debe finalizar');
+  assert.strictEqual(eventoMultidia.estado, 'En espera', 'Evento multidía pasa a espera');
+  assert.ok(logs.some(m => m.includes('continuará el día siguiente')), 'Debe registrar continuación');
+
+  // Simular siguiente día para reanudar
+  Evento.find = async (query) => {
+    if (query.estado === 'activo') return [];
+    if (query.estado === 'En proceso') return [];
+    if (query.estado === 'En espera') return [eventoMultidia];
+    return [];
+  };
+
+  await actualizarEventosEnProceso(new Date('2024-01-02T17:05:00Z'));
+
+  assert.strictEqual(eventoMultidia.estado, 'En proceso', 'Evento multidía se reanuda');
+
+  console.log('✅ Pruebas de eventoCron completadas');
+  process.exit(0);
+})();
+


### PR DESCRIPTION
## Summary
- add "En espera" status for multi-day events that pause overnight
- resume paused events at the next day's start and document new state

## Testing
- `node src/test/eventoCron.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689bbbaab6d88330a3053bf9d843b0f9