### PR TITLE
Track attendance per event participant

### DIFF
--- a/src/controllers/asistencia.controller.js
+++ b/src/controllers/asistencia.controller.js
@@ -66,6 +66,7 @@ exports.registrarAsistencia = async (req, res) => {
     });
 
     await asistencia.save();
+    await Evento.findByIdAndUpdate(eventoId, { $addToSet: { participantesRegistrados: asistencia._id } });
     await incrementMetric("asistencias");
     await incrementEventMetric(eventoId, dentroDelRango ? 'dentroDelRango' : 'fueraDelRango');
 

--- a/src/controllers/evento.controller.js
+++ b/src/controllers/evento.controller.js
@@ -94,7 +94,11 @@ exports.obtenerEventos = async (req, res) => {
   try {
     // ✅ Sin filtro, trae todos los eventos
     const eventos = await Evento.find()
-      .populate('creadorId', 'nombre email rol');
+      .populate('creadorId', 'nombre email rol')
+      .populate({
+        path: 'participantesRegistrados',
+        populate: { path: 'estudiante', select: 'nombre email' }
+      });
 
     res.status(200).json(eventos);
   } catch (err) {
@@ -109,7 +113,12 @@ exports.obtenerEventos = async (req, res) => {
 // Obtener evento por ID
 exports.obtenerEventoPorId = async (req, res) => {
   try {
-    const evento = await Evento.findOne({ _id: req.params.id, }).populate('creadorId', 'nombre email');
+    const evento = await Evento.findOne({ _id: req.params.id, })
+      .populate('creadorId', 'nombre email')
+      .populate({
+        path: 'participantesRegistrados',
+        populate: { path: 'estudiante', select: 'nombre email' }
+      });
     if (!evento) return res.status(404).json({ mensaje: 'Evento no encontrado' });
     res.status(200).json(evento);
   } catch (err) {
@@ -244,7 +253,12 @@ exports.obtenerMisEventos = async (req, res) => {
     const filtro = { creadorId: req.user.id };
     if (estado) filtro.estado = estado;
 
-    const eventos = await Evento.find(filtro).populate('creadorId', 'nombre email rol');
+    const eventos = await Evento.find(filtro)
+      .populate('creadorId', 'nombre email rol')
+      .populate({
+        path: 'participantesRegistrados',
+        populate: { path: 'estudiante', select: 'nombre email' }
+      });
     res.status(200).json(eventos);
   } catch (err) {
     res.status(500).json({ mensaje: 'Error al obtener mis eventos', error: err.message });

--- a/src/models/model.evento.js
+++ b/src/models/model.evento.js
@@ -61,7 +61,7 @@ const eventoSchema = new mongoose.Schema({
     default: 'activo'
   },
   reportePDF: { type: String },
-  participantesRegistrados: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Usuario' }],
+  participantesRegistrados: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Asistencia' }],
   fechaCreacion: { type: Date, default: Date.now }
 }, {
   timestamps: true


### PR DESCRIPTION
## Summary
- Store asistencia references in Evento.participantesRegistrados
- Link asistencia entries to events when registering attendance
- Populate registered participants with student info when retrieving events

## Testing
- `npm test` *(fails: Missing script "test")*
- `node src/test/asistencia.test.js`
- `node src/test/eventoCron.test.js`
- `node src/test/test-mail.js` *(fails: Error: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68a86ac5a8d0833080895b6382211a3d